### PR TITLE
feature/bug/471298-CS-member-Resubmission-API-Outstanding-payments-is-not-showing-any-amount-less-than-0

### DIFF
--- a/src/EPR.Payment.Service.UnitTests/Services/ResubmissionFees/ComplianceScheme/ComplianceSchemeResubmissionServiceTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Services/ResubmissionFees/ComplianceScheme/ComplianceSchemeResubmissionServiceTests.cs
@@ -344,7 +344,7 @@ namespace EPR.Payment.Service.UnitTests.Services.ResubmissionFees.ComplianceSche
 
                 // OutstandingPayment should be equal to totalFee - previousPayments
                 var outstandingPayment = expectedTotalFee - previousPayments;
-                result.OutstandingPayment.Should().Be(0m);
+                result.OutstandingPayment.Should().Be(-5000m);
             }
         }
     }

--- a/src/EPR.Payment.Service/Services/ResubmissionFees/ComplianceScheme/ComplianceSchemeResubmissionService.cs
+++ b/src/EPR.Payment.Service/Services/ResubmissionFees/ComplianceScheme/ComplianceSchemeResubmissionService.cs
@@ -38,7 +38,7 @@ namespace EPR.Payment.Service.Services.ResubmissionFees.ComplianceScheme
             {
                 TotalResubmissionFee = totalFee,
                 PreviousPayments = previousPayments,
-                OutstandingPayment = outstandingPayment > 0 ? outstandingPayment : 0,
+                OutstandingPayment = outstandingPayment,
                 MemberCount = request.MemberCount
             };
         }


### PR DESCRIPTION
471298 CS member Resubmission API - Outstanding payments is not showing any amount less than 0