### PR TITLE
remove future date validation

### DIFF
--- a/src/EPR.Payment.Service.Common.Data/Repositories/Fees/BaseFeeRepository.cs
+++ b/src/EPR.Payment.Service.Common.Data/Repositories/Fees/BaseFeeRepository.cs
@@ -5,6 +5,7 @@ using EPR.Payment.Service.Common.Data.Helper;
 using EPR.Payment.Service.Common.Data.Interfaces;
 using EPR.Payment.Service.Common.ValueObjects.RegistrationFees;
 using Microsoft.EntityFrameworkCore;
+using RegistrationFeesEntity = EPR.Payment.Service.Common.Data.DataModels.Lookups.RegistrationFees;
 
 namespace EPR.Payment.Service.Common.Data.Repositories.RegistrationFees
 {
@@ -26,28 +27,31 @@ namespace EPR.Payment.Service.Common.Data.Repositories.RegistrationFees
             DateTime submissionDate,
             CancellationToken cancellationToken)
         {
-            decimal fee = 0;
             string inMemoryKey = GetInMemoryKey(groupType, subGroupType, regulator);
-            var cachedFee = _keyValueStore.Get(inMemoryKey);
-            if (cachedFee != null)
-            {
-                return (decimal)cachedFee;
-            }
-       
-            var registrationFees = await _dataContext.RegistrationFees
-                .Where(r => r.Group.Type.ToLower().Equals(groupType.ToLower())  &&
-                r.SubGroup.Type.ToLower().Equals(subGroupType.ToLower()) &&
-                r.Regulator.Type.ToLower().Equals(regulator.Value.ToLower())) 
-               .ToListAsync(cancellationToken);
 
-            if (registrationFees.Count==0)
+            List<RegistrationFeesEntity> registrationFees;
+            if (_keyValueStore.Get(inMemoryKey) is List<RegistrationFeesEntity> cachedRows)
             {
-                _keyValueStore.Add(inMemoryKey, fee);
-                return fee;
+                registrationFees = cachedRows;
+            }
+            else
+            {
+                registrationFees = await _dataContext.RegistrationFees
+                    .Where(r => r.Group.Type.ToLower().Equals(groupType.ToLower()) &&
+                                r.SubGroup.Type.ToLower().Equals(subGroupType.ToLower()) &&
+                                r.Regulator.Type.ToLower().Equals(regulator.Value.ToLower()))
+                    .ToListAsync(cancellationToken);
+                _keyValueStore.Add(inMemoryKey, registrationFees);
             }
 
-            fee = registrationFees
-                .Where(r => submissionDate >= r.EffectiveFrom && submissionDate <= r.EffectiveTo)
+            if (registrationFees.Count == 0)
+            {
+                return 0;
+            }
+
+            var submissionDateOnly = submissionDate.Date;
+            var fee = registrationFees
+                .Where(r => submissionDateOnly >= r.EffectiveFrom.Date && submissionDateOnly <= r.EffectiveTo.Date)
                 .OrderByDescending(r => r.EffectiveFrom)
                 .Select(r => r.Amount)
                 .FirstOrDefault();
@@ -56,8 +60,6 @@ namespace EPR.Payment.Service.Common.Data.Repositories.RegistrationFees
             {
                 throw new ArgumentException(subGroupType == SubGroupTypeConstants.ReSubmitting ? ValidationMessages.ResubmissionDateIsNotInRange : ValidationMessages.SubmissionDateIsNotInRange);
             }
-
-            _keyValueStore.Add(inMemoryKey, fee);
 
             return fee;
         }

--- a/src/EPR.Payment.Service.Common/Constants/Fees/ValidationMessages.cs
+++ b/src/EPR.Payment.Service.Common/Constants/Fees/ValidationMessages.cs
@@ -51,11 +51,9 @@ namespace EPR.Payment.Service.Common.Constants.RegistrationFees
         public const string PayerIdRequired = "PayerId is required";
 
         public const string InvalidSubmissionDate = "Submission date is mandatory and must be a valid date.";
-        public const string FutureSubmissionDate = "Submission date cannot be a date in the future.";
         public const string SubmissionDateMustBeUtc = "Submission date must be in the UTC format which is YYYY-MM-DDTHH:MM:SSZ.";
         public const string SubmissionDateIsNotInRange = "Fee data is not available for given submission date.";
         public const string ResubmissionDateRequired = "Resubmission date is mandatory and must be a valid date.";
-        public const string FutureResubmissionDate = "Resubmission date cannot be a date in the future.";
         public const string ResubmissionDateMustBeUtc = "Resubmission date must be in the UTC format which is YYYY-MM-DDTHH:MM:SSZ.";
         public const string ResubmissionDateIsNotInRange = "Fee data is not available for given resubmission date.";
         public const string ReferenceNumberRequired = "Reference Number is required.";        

--- a/src/EPR.Payment.Service.Data.UnitTests/Repositories/Fees/BaseFeeRepositoryTests.cs
+++ b/src/EPR.Payment.Service.Data.UnitTests/Repositories/Fees/BaseFeeRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using EPR.Payment.Service.Common.Constants.RegistrationFees.LookUps;
+using EPR.Payment.Service.Common.Constants.RegistrationFees;
+using EPR.Payment.Service.Common.Constants.RegistrationFees.LookUps;
 using EPR.Payment.Service.Common.Data.Helper;
 using EPR.Payment.Service.Common.Data.Interfaces;
 using EPR.Payment.Service.Common.Data.Repositories.RegistrationFees;
@@ -49,25 +50,34 @@ namespace EPR.Payment.Service.Data.UnitTests.Repositories.Fees
         }
 
         [TestMethod]
-        public async Task GetFeeAsync_IfKeyExistsInMemory_ShouldReturnFeeFromMemory()
+        public async Task GetFeeAsync_IfKeyExistsInMemory_ShouldReturnFeeFromMemoryWithoutHittingDatabase()
         {
             // Arrange
             var groupType = GroupTypeConstants.ProducerType;
             var subGroupType = "Small";
             var regulator = RegulatorType.Create("GB-ENG");
             var submissionDate = DateTime.UtcNow;
-            var expectedFee = 100m;
+            var expectedFee = 121600m;
 
-            // Act
+            var cachedRows = new List<Common.Data.DataModels.Lookups.RegistrationFees>
+            {
+                new Common.Data.DataModels.Lookups.RegistrationFees
+                {
+                    Amount = expectedFee,
+                    EffectiveFrom = DateTime.UtcNow.AddDays(-10),
+                    EffectiveTo = DateTime.UtcNow.AddDays(10),
+                },
+            };
+
             var getInMemoryKeyMethod = typeof(BaseFeeRepository).GetMethod("GetInMemoryKey", BindingFlags.Static | BindingFlags.NonPublic);
             var inMemoryKey = (string?)getInMemoryKeyMethod!.Invoke(null, [groupType, subGroupType, regulator]);
+            _keyValueStore.Add(inMemoryKey!, cachedRows);
 
-            _keyValueStore.Add(inMemoryKey!, expectedFee);
-
+            // Act
             var result = await _repository.GetFeeAsyncPublic(groupType, subGroupType, regulator, submissionDate, CancellationToken.None);
 
             // Assert
-            using(new AssertionScope())
+            using (new AssertionScope())
             {
                 result.Should().Be(expectedFee);
                 _dbContextMock.Verify(x => x.RegistrationFees, Times.Never);
@@ -75,7 +85,7 @@ namespace EPR.Payment.Service.Data.UnitTests.Repositories.Fees
         }
 
         [TestMethod]
-        public async Task GetFeeAsync_IfKeyDoesNotExistInMemory_ShouldFetchFeeFromDatabase()
+        public async Task GetFeeAsync_IfKeyDoesNotExistInMemory_ShouldFetchRowsFromDatabaseAndCacheThem()
         {
             // Arrange
             var groupType = GroupTypeConstants.ProducerType;
@@ -86,19 +96,103 @@ namespace EPR.Payment.Service.Data.UnitTests.Repositories.Fees
 
             _dbContextMock.Setup(i => i.RegistrationFees).ReturnsDbSet(_registrationFeesMock.Object);
 
-            // Act
             var getInMemoryKeyMethod = typeof(BaseFeeRepository).GetMethod("GetInMemoryKey", BindingFlags.Static | BindingFlags.NonPublic);
             var inMemoryKey = (string?)getInMemoryKeyMethod!.Invoke(null, [groupType, subGroupType, regulator]);
 
+            // Act
             var result = await _repository.GetFeeAsyncPublic(groupType, subGroupType, regulator, submissionDate, CancellationToken.None);
 
             // Assert
             using (new AssertionScope())
             {
                 result.Should().Be(expectedFee);
-                _keyValueStore.Data.Should().ContainKey(inMemoryKey!).And.Subject[inMemoryKey!].Should().Be(expectedFee);
+                _keyValueStore.Data.Should().ContainKey(inMemoryKey!);
+                _keyValueStore.Data[inMemoryKey!].Should().BeOfType<List<Common.Data.DataModels.Lookups.RegistrationFees>>();
             }
+        }
 
+        [TestMethod]
+        public async Task GetFeeAsync_WhenQueriedAcrossDifferentDateBands_ShouldReturnCorrectFeePerDate()
+        {
+            // Regression test: previously the cache stored a single decimal keyed without the
+            // submission date, so whichever date hit the cache first pinned the fee. Now the cache
+            // stores the row set and each call filters by date.
+
+            // Arrange
+            var groupType = GroupTypeConstants.ComplianceScheme;
+            var subGroupType = ComplianceSchemeConstants.Registration;
+            var regulator = RegulatorType.Create("GB-ENG");
+
+            _dbContextMock.Setup(i => i.RegistrationFees).ReturnsDbSet(_registrationFeesMock.Object);
+
+            // Expired-band row: EffectiveFrom = UtcNow-30, EffectiveTo = UtcNow-15, Amount = 1280400.
+            // Future-effective row: EffectiveFrom = UtcNow+5, EffectiveTo = UtcNow+20, Amount = 1480400.
+            var expiredDate = DateTime.UtcNow.AddDays(-20);
+            var futureDate = DateTime.UtcNow.AddDays(10);
+
+            // Act — query the expired band first so it would have poisoned the old cache.
+            var expiredFee = await _repository.GetFeeAsyncPublic(groupType, subGroupType, regulator, expiredDate, CancellationToken.None);
+            var futureFee = await _repository.GetFeeAsyncPublic(groupType, subGroupType, regulator, futureDate, CancellationToken.None);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                expiredFee.Should().Be(1280400m);
+                futureFee.Should().Be(1480400m);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetFeeAsync_FutureSubmissionDateCoveredByExistingRow_ShouldReturnThatRowsAmount()
+        {
+            // Arrange
+            var groupType = GroupTypeConstants.ComplianceScheme;
+            var subGroupType = ComplianceSchemeConstants.Registration;
+            var regulator = RegulatorType.Create("GB-ENG");
+            var futureDate = DateTime.UtcNow.AddDays(15);
+
+            _dbContextMock.Setup(i => i.RegistrationFees).ReturnsDbSet(_registrationFeesMock.Object);
+
+            // Act
+            var result = await _repository.GetFeeAsyncPublic(groupType, subGroupType, regulator, futureDate, CancellationToken.None);
+
+            // Assert — matches the "Future Effective" compliance scheme row (Amount = 1480400).
+            result.Should().Be(1480400m);
+        }
+
+        [TestMethod]
+        public async Task GetFeeAsync_FutureSubmissionDateNotCoveredByAnyRow_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var groupType = GroupTypeConstants.ComplianceScheme;
+            var subGroupType = ComplianceSchemeConstants.Registration;
+            var regulator = RegulatorType.Create("GB-ENG");
+            var farFutureDate = DateTime.UtcNow.AddYears(5);
+
+            _dbContextMock.Setup(i => i.RegistrationFees).ReturnsDbSet(_registrationFeesMock.Object);
+
+            // Act & Assert
+            await _repository.Invoking(r => r.GetFeeAsyncPublic(groupType, subGroupType, regulator, farFutureDate, CancellationToken.None))
+                .Should().ThrowAsync<ArgumentException>()
+                .WithMessage(ValidationMessages.SubmissionDateIsNotInRange);
+        }
+
+        [TestMethod]
+        public async Task GetFeeAsync_WhenNoRowsExistForGroupSubGroupRegulator_ShouldReturnZero()
+        {
+            // Arrange
+            var groupType = GroupTypeConstants.ProducerType;
+            var subGroupType = "Small";
+            var regulator = RegulatorType.Create("GB-SCT");
+            var submissionDate = DateTime.UtcNow;
+
+            _dbContextMock.Setup(i => i.RegistrationFees).ReturnsDbSet(_registrationFeesMock.Object);
+
+            // Act
+            var result = await _repository.GetFeeAsyncPublic(groupType, subGroupType, regulator, submissionDate, CancellationToken.None);
+
+            // Assert
+            result.Should().Be(0m);
         }
     }
 

--- a/src/EPR.Payment.Service.UnitTests/Validations/AccreditationFees/AccreditatonFeesRequestDtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/AccreditationFees/AccreditatonFeesRequestDtoValidatorTests.cs
@@ -123,7 +123,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.AccreditationFees
         }
 
         [TestMethod]
-        public void Validate_FutureSubmissionDate_ShouldHaveError()
+        public void Validate_FutureSubmissionDate_ShouldNotHaveError()
         {
             // Arrange
             var request = new ReprocessorOrExporterAccreditationFeesRequestDto
@@ -141,8 +141,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.AccreditationFees
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.SubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureSubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.SubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ComplianceSchemeFeesRequestDtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ComplianceSchemeFeesRequestDtoValidatorTests.cs
@@ -105,7 +105,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
         }
 
         [TestMethod]
-        public void Validator_Should_Fail_When_SubmissionDate_Is_Future_Date()
+        public void Validator_Should_Not_Fail_When_SubmissionDate_Is_Future_Date()
         {
             // Arrange
             var dto = new ComplianceSchemeFeesRequestDto
@@ -120,8 +120,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
             var result = _validator.TestValidate(dto);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.SubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureSubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.SubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ComplianceSchemeFeesRequestV2DtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ComplianceSchemeFeesRequestV2DtoValidatorTests.cs
@@ -125,7 +125,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
         }
 
         [TestMethod]
-        public void Validator_Should_Fail_When_SubmissionDate_Is_Future_Date()
+        public void Validator_Should_Not_Fail_When_SubmissionDate_Is_Future_Date()
         {
             // Arrange
             var dto = new ComplianceSchemeFeesRequestV2Dto
@@ -145,8 +145,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
             var result = _validator.TestValidate(dto);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.SubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureSubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.SubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ProducerRegistrationFeeRequestDtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ProducerRegistrationFeeRequestDtoValidatorTests.cs
@@ -428,7 +428,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
         }
 
         [TestMethod]
-        public void Validate_FutureSubmissionDate_ShouldHaveError()
+        public void Validate_FutureSubmissionDate_ShouldNotHaveError()
         {
             // Arrange
             var request = new ProducerRegistrationFeesRequestV2Dto
@@ -451,8 +451,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.SubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureSubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.SubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ReprocessorOrExporterRegistrationFeeRequestDtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/RegistrationFees/ReprocessorOrExporterRegistrationFeeRequestDtoValidatorTests.cs
@@ -145,7 +145,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
         }
 
         [TestMethod]
-        public void Validate_FutureSubmissionDate_ShouldHaveError()
+        public void Validate_FutureSubmissionDate_ShouldNotHaveError()
         {
             // Arrange
             var request = new ReprocessorOrExporterRegistrationFeesRequestDto
@@ -161,8 +161,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.RegistrationFees
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.SubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureSubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.SubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service.UnitTests/Validations/ResubmissionFees/ComplianceSchemeResubmissionFeeRequestDtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/ResubmissionFees/ComplianceSchemeResubmissionFeeRequestDtoValidatorTests.cs
@@ -77,7 +77,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.ResubmissionFees
         }
 
         [TestMethod]
-        public void Validate_ResubmissionDateIsInTheFuture_ShouldHaveValidationError()
+        public void Validate_ResubmissionDateIsInTheFuture_ShouldNotHaveValidationError()
         {
             // Arrange
             var dto = new ComplianceSchemeResubmissionFeeRequestDto
@@ -92,8 +92,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.ResubmissionFees
             var result = _validator.TestValidate(dto);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.ResubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureResubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.ResubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service.UnitTests/Validations/ResubmissionFees/ProducerResubmissionFeeRequestDtoValidatorTests.cs
+++ b/src/EPR.Payment.Service.UnitTests/Validations/ResubmissionFees/ProducerResubmissionFeeRequestDtoValidatorTests.cs
@@ -74,7 +74,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.ResubmissionFees
         }
 
         [TestMethod]
-        public void Validate_ResubmissionDateIsInTheFuture_ShouldHaveValidationError()
+        public void Validate_ResubmissionDateIsInTheFuture_ShouldNotHaveValidationError()
         {
             // Arrange
             var dto = new ProducerResubmissionFeeRequestDto
@@ -88,8 +88,7 @@ namespace EPR.Payment.Service.UnitTests.Validations.ResubmissionFees
             var result = _validator.TestValidate(dto);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.ResubmissionDate)
-                  .WithErrorMessage(ValidationMessages.FutureResubmissionDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.ResubmissionDate);
         }
 
         [TestMethod]

--- a/src/EPR.Payment.Service/Validations/Common/CustomDateValidationRules.cs
+++ b/src/EPR.Payment.Service/Validations/Common/CustomDateValidationRules.cs
@@ -10,8 +10,7 @@ namespace EPR.Payment.Service.Validations.Common
         {
             return ruleBuilder
                 .NotEmpty().WithMessage(ValidationMessages.InvalidSubmissionDate)
-                .Must(BeInUtc).WithMessage(ValidationMessages.SubmissionDateMustBeUtc)
-                .LessThanOrEqualTo(DateTime.UtcNow).WithMessage(ValidationMessages.FutureSubmissionDate);
+                .Must(BeInUtc).WithMessage(ValidationMessages.SubmissionDateMustBeUtc);
         }
 
 
@@ -19,8 +18,7 @@ namespace EPR.Payment.Service.Validations.Common
         {
             return ruleBuilder
                 .NotEmpty().WithMessage(ValidationMessages.ResubmissionDateRequired)
-                .Must(BeInUtc).WithMessage(ValidationMessages.ResubmissionDateMustBeUtc)
-                .LessThanOrEqualTo(DateTime.UtcNow).WithMessage(ValidationMessages.FutureResubmissionDate);
+                .Must(BeInUtc).WithMessage(ValidationMessages.ResubmissionDateMustBeUtc);
         }
 
         private static bool BeInUtc(DateTime dateTime)


### PR DESCRIPTION
allow interrogation of registration fees at a future date
correction to cache handling - cache fees by key for date ranges so that varying submission date will be acknowledged
 - by chance doesn't cause issue due to scoped lifetime but fragile code