### PR TITLE
SUB-230, DD. Added message bus tests for out-of-order messages

### DIFF
--- a/src/EPR.Payment.Service.Common.Data/Repositories/RegistrationSubmission/RegistrationSubmissionDataRepository.cs
+++ b/src/EPR.Payment.Service.Common.Data/Repositories/RegistrationSubmission/RegistrationSubmissionDataRepository.cs
@@ -28,7 +28,7 @@ namespace EPR.Payment.Service.Common.Data.Repositories.RegistrationSubmission
                 .Include(r => r.Producers)
                     .ThenInclude(p => p.Subsidiaries)
                 .Where(r => r.SubmissionId == submissionId)
-                .OrderByDescending(r => r.CreatedDate)
+                .OrderByDescending(r => r.SubmissionDate)
                 .FirstOrDefaultAsync(cancellationToken);
         }
 

--- a/src/EPR.Payment.Service.Data.UnitTests/Repositories/RegistrationSubmission/RegistrationSubmissionDataRepositoryTests.cs
+++ b/src/EPR.Payment.Service.Data.UnitTests/Repositories/RegistrationSubmission/RegistrationSubmissionDataRepositoryTests.cs
@@ -75,32 +75,6 @@ namespace EPR.Payment.Service.Data.UnitTests.Repositories.RegistrationSubmission
         }
 
         [TestMethod]
-        public async Task GetLatestWithProducersAndSubsidiariesAsync_MultipleRows_ReturnsMostRecent()
-        {
-            var submissionId = Guid.NewGuid();
-            var older = new RegistrationSubmissionData
-            {
-                Id = Guid.NewGuid(),
-                SubmissionId = submissionId,
-                CreatedDate = new DateTimeOffset(2026, 5, 28, 0, 0, 0, TimeSpan.Zero),
-                Producers = new List<RegistrationSubmissionProducer>(),
-            };
-            var newer = new RegistrationSubmissionData
-            {
-                Id = Guid.NewGuid(),
-                SubmissionId = submissionId,
-                CreatedDate = new DateTimeOffset(2026, 5, 29, 0, 0, 0, TimeSpan.Zero),
-                Producers = new List<RegistrationSubmissionProducer>(),
-            };
-            _dataContextMock.Setup(c => c.RegistrationSubmissionData).ReturnsDbSet(new[] { older, newer });
-
-            var result = await _sut.GetLatestWithProducersAndSubsidiariesAsync(submissionId, _ct);
-
-            result.Should().NotBeNull();
-            result!.Id.Should().Be(newer.Id);
-        }
-
-        [TestMethod]
         public async Task CreateAsync_AddsEntityAndSavesOnce()
         {
             var dbSetMock = new Mock<DbSet<RegistrationSubmissionData>>();

--- a/src/EPR.Payment.Service.IntegrationTests/Features/RegistrationSubmissionIntegrationTests.cs
+++ b/src/EPR.Payment.Service.IntegrationTests/Features/RegistrationSubmissionIntegrationTests.cs
@@ -67,4 +67,78 @@ public class RegistrationSubmissionIntegrationTests(ServiceFixture fixture) : In
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+    
+    [Fact]
+    public async Task GIVEN_two_message_received_in_order_WHEN_RegistrationSubmittedMessage_consumed_THEN_second_message_generates_fees()
+    {
+        // Arrange
+        var earlierSubmissionDateRegistrationFile = await Builder.RegistrationFileBuilder().Build();
+        var laterSubmissionDateRegistrationFile = await Builder.RegistrationFileBuilder().Build(earlierSubmissionDateRegistrationFile.SubmissionId);
+
+        // the submission date determines the order. the later submission date should be the one that is used to generate fees
+        var earlierSubmissionDateMessage = new RegistrationSubmittedMessage(
+            SubmissionId: earlierSubmissionDateRegistrationFile.SubmissionId,
+            RegistrationBlobName: earlierSubmissionDateRegistrationFile.RegistrationBlobName,
+            ComplianceSchemeId: null,
+            SubmissionPeriod: "2024-P1",
+            SubmissionDate: new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+        
+        await SendMessageAndWaitUntilConsumed(earlierSubmissionDateMessage);
+
+        var laterSubmissionDateMessage = new RegistrationSubmittedMessage(
+            SubmissionId: laterSubmissionDateRegistrationFile.SubmissionId,
+            RegistrationBlobName: laterSubmissionDateRegistrationFile.RegistrationBlobName,
+            ComplianceSchemeId: null,
+            SubmissionPeriod: "2024-P1",
+            SubmissionDate: new DateTime(2024, 2, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        // act
+        await SendMessageAndWaitUntilConsumed(laterSubmissionDateMessage);
+        
+        // Assert
+        var response = await Client.GetAsync($"/api/v1/registration-submission-data/{laterSubmissionDateRegistrationFile.SubmissionId}/fee-calculation-details");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var details = await response.ReadJson<List<RegistrationFeeCalculationDetailsDto>>();
+
+        details.Should().HaveCount(1);
+        var item = details[0];
+        item.OrganisationId.Should().Be(laterSubmissionDateRegistrationFile.BuiltRegistrationFileItems[0].OrganisationId);
+    }
+    
+    [Fact]
+    public async Task GIVEN_two_message_received_in_wrong_order_WHEN_RegistrationSubmittedMessage_consumed_THEN_first_message_generates_fees()
+    {
+        // Arrange
+        var earlierSubmissionDateRegistrationFile = await Builder.RegistrationFileBuilder().Build();
+        var laterSubmissionDateRegistrationFile = await Builder.RegistrationFileBuilder().Build(earlierSubmissionDateRegistrationFile.SubmissionId);
+
+        // the submission date determines the order. the later submission date should be the one that is used to generate fees
+        var laterSubmissionDateMessage = new RegistrationSubmittedMessage(
+            SubmissionId: laterSubmissionDateRegistrationFile.SubmissionId,
+            RegistrationBlobName: laterSubmissionDateRegistrationFile.RegistrationBlobName,
+            ComplianceSchemeId: null,
+            SubmissionPeriod: "2024-P1",
+            SubmissionDate: new DateTime(2024, 2, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        await SendMessageAndWaitUntilConsumed(laterSubmissionDateMessage);
+
+        var earlierSubmissionDateMessage = new RegistrationSubmittedMessage(
+            SubmissionId: earlierSubmissionDateRegistrationFile.SubmissionId,
+            RegistrationBlobName: earlierSubmissionDateRegistrationFile.RegistrationBlobName,
+            ComplianceSchemeId: null,
+            SubmissionPeriod: "2024-P1",
+            SubmissionDate: new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+        
+        // act
+        await SendMessageAndWaitUntilConsumed(earlierSubmissionDateMessage);
+        
+        // Assert
+        var response = await Client.GetAsync($"/api/v1/registration-submission-data/{laterSubmissionDateRegistrationFile.SubmissionId}/fee-calculation-details");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var details = await response.ReadJson<List<RegistrationFeeCalculationDetailsDto>>();
+
+        details.Should().HaveCount(1);
+        var item = details[0];
+        item.OrganisationId.Should().Be(laterSubmissionDateRegistrationFile.BuiltRegistrationFileItems[0].OrganisationId);
+    }
 }

--- a/src/EPR.Payment.Service.IntegrationTests/Infrastructure/Builders/Registrations/RegistrationFileBuilder.cs
+++ b/src/EPR.Payment.Service.IntegrationTests/Infrastructure/Builders/Registrations/RegistrationFileBuilder.cs
@@ -5,12 +5,12 @@ namespace EPR.Payment.Service.IntegrationTests.Infrastructure.Builders.Registrat
 /// </summary>
 public sealed class RegistrationFileBuilder(TestBuilders builders)
 {
-    public async Task<BuiltRegistrationFile> Build()
+    public async Task<BuiltRegistrationFile> Build(Guid? existingSubmissionId = null)
     {
         BuiltRegistrationFile registrationFile = null!;
         await builders.WithBlobContainer(async ctx =>
         {
-            registrationFile = await RegistrationSubmissionBlobFileGenerator.StoreRandomRegistrationCsv(ctx);
+            registrationFile = await RegistrationSubmissionBlobFileGenerator.StoreRandomRegistrationCsv(ctx, existingSubmissionId);
         });
         return registrationFile;
     }

--- a/src/EPR.Payment.Service.IntegrationTests/Infrastructure/Builders/Registrations/RegistrationSubmissionBlobFileGenerator.cs
+++ b/src/EPR.Payment.Service.IntegrationTests/Infrastructure/Builders/Registrations/RegistrationSubmissionBlobFileGenerator.cs
@@ -4,14 +4,19 @@ namespace EPR.Payment.Service.IntegrationTests.Infrastructure.Builders.Registrat
 
 public static class RegistrationSubmissionBlobFileGenerator
 {
+    private static int counter;
+    private static string GetNewId() => Interlocked.Increment(ref counter).ToString();
+    
     private static readonly string[] CsvHeader =
         ["organisation_id,subsidiary_id,home_nation_code,organisation_size,packaging_activity_om,joiner_date,closed_loop_registration"];
-    public static async Task<BuiltRegistrationFile> StoreRandomRegistrationCsv(BlobContainerClient blobContainerClient)
+    public static async Task<BuiltRegistrationFile> StoreRandomRegistrationCsv(BlobContainerClient blobContainerClient,
+        Guid? existingSubmissionId)
     {
-        const string orgId = "ORG001";
-        const string subsidiaryId = "SUB001";
-        var submissionId = Guid.NewGuid();
-        var blobName = $"{submissionId:N}.csv";
+        var orgId = $"ORG{GetNewId()}";
+        var subsidiaryId = $"SUB{GetNewId()}";
+        var blobId = $"BLOB{GetNewId()}";
+        var submissionId = existingSubmissionId ?? Guid.NewGuid();
+        var blobName = $"{blobId}.csv";
 
         var parentOrgRegistration = new BuiltRegistrationFileItem(orgId, null, "EN", "L", "Primary", new DateTime(2024, 1, 1), true);
         var subsidiaryRegistration = new BuiltRegistrationFileItem(orgId, subsidiaryId, null, null, null, null, true);

--- a/src/EPR.Payment.Service.Messaging/ServiceBusTopicSubscription.cs
+++ b/src/EPR.Payment.Service.Messaging/ServiceBusTopicSubscription.cs
@@ -89,8 +89,6 @@ public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
     {
         var message = args.Message.Body.ToObjectFromJson<RegistrationSubmittedMessage>();
 
-        Thread.Sleep(15000);
-            
         if (message is null)
         {
             _logger.LogWarning("Received a null or undeserializable message, skipping");


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SUB-230

Test that if messages are consumed in the wrong order, then the message with the later submission date is the one that is used to generate fees. Order registration data by submit date in order to ensure that the tests pass!

<img width="1249" height="579" alt="image" src="https://github.com/user-attachments/assets/5b48c77c-3801-4585-9d1f-98ebe3a348ac" />
