### PR TITLE
Implement migration to extend registration fees' effective end dates …

### DIFF
--- a/src/EPR.Payment.Service.Common.Data/Migrations/20260716085126_ExtendCurrentFeesEndDatesTo2050.Designer.cs
+++ b/src/EPR.Payment.Service.Common.Data/Migrations/20260716085126_ExtendCurrentFeesEndDatesTo2050.Designer.cs
@@ -4,6 +4,7 @@ using EPR.Payment.Service.Common.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EPR.Payment.Service.Common.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716085126_ExtendCurrentFeesEndDatesTo2050")]
+    partial class ExtendCurrentFeesEndDatesTo2050
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EPR.Payment.Service.Common.Data/Migrations/20260716085126_ExtendCurrentFeesEndDatesTo2050.cs
+++ b/src/EPR.Payment.Service.Common.Data/Migrations/20260716085126_ExtendCurrentFeesEndDatesTo2050.cs
@@ -1,0 +1,1107 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EPR.Payment.Service.Common.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExtendCurrentFeesEndDatesTo2050 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000000,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000001,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000002,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000003,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000004,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000005,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000006,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000007,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000008,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000009,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000010,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000011,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000012,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000013,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000014,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000015,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000016,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000017,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000018,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000019,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000020,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000021,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000022,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000023,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000024,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000025,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000026,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000027,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000028,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000029,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000030,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000031,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000032,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000033,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000034,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000035,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000036,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000037,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000038,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000039,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000040,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000041,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000042,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000043,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000044,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000045,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000046,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000047,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000048,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000049,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000050,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000051,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000052,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000053,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000054,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000055,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000056,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000057,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000058,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000059,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000060,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000061,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000062,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000063,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000064,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000065,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000066,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000067,
+                column: "EffectiveTo",
+                value: new DateTime(2050, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000000,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000001,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000002,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000003,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000004,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000005,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000006,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000007,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000008,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000009,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000010,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000011,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000012,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000013,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000014,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000015,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000016,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000017,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000018,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000019,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000020,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000021,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000022,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000023,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000024,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000025,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000026,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000027,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000028,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000029,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000030,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000031,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000032,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000033,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000034,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000035,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000036,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000037,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000038,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000039,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000040,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000041,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000042,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000043,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000044,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000045,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000046,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000047,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000048,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000049,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000050,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000051,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000052,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000053,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000054,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000055,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000056,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000057,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000058,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000059,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000060,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000061,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000062,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000063,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000064,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000065,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000066,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                schema: "Lookup",
+                table: "RegistrationFees",
+                keyColumn: "Id",
+                keyValue: 26000067,
+                column: "EffectiveTo",
+                value: new DateTime(2026, 12, 31, 23, 59, 59, 0, DateTimeKind.Utc));
+        }
+    }
+}

--- a/src/EPR.Payment.Service.Common.Data/Migrations/SQLScripts/20260716085126_ExtendCurrentFeesEndDatesTo2050_Release.sql
+++ b/src/EPR.Payment.Service.Common.Data/Migrations/SQLScripts/20260716085126_ExtendCurrentFeesEndDatesTo2050_Release.sql
@@ -1,0 +1,764 @@
+﻿BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000000;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000001;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000002;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000003;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000004;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000005;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000006;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000007;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000008;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000009;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000010;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000011;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000012;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000013;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000014;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000015;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000016;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000017;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000018;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000019;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000020;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000021;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000022;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000023;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000024;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000025;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000026;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000027;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000028;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000029;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000030;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000031;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000032;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000033;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000034;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000035;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000036;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000037;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000038;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000039;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000040;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000041;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000042;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000043;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000044;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000045;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000046;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000047;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000048;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000049;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000050;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000051;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000052;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000053;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000054;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000055;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000056;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000057;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000058;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000059;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000060;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000061;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000062;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000063;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000064;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000065;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000066;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000067;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20260716085126_ExtendCurrentFeesEndDatesTo2050', N'8.0.28');
+END;
+GO
+
+COMMIT;
+GO
+

--- a/src/EPR.Payment.Service.Common.Data/Migrations/SQLScripts/20260716085126_ExtendCurrentFeesEndDatesTo2050_Rollback.sql
+++ b/src/EPR.Payment.Service.Common.Data/Migrations/SQLScripts/20260716085126_ExtendCurrentFeesEndDatesTo2050_Rollback.sql
@@ -1,0 +1,764 @@
+﻿BEGIN TRANSACTION;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000000;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000001;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000002;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000003;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000004;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000005;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000006;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000007;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000008;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000009;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000010;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000011;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000012;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000013;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000014;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000015;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000016;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000017;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000018;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000019;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000020;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000021;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000022;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000023;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000024;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000025;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000026;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000027;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000028;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000029;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000030;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000031;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000032;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000033;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000034;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000035;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000036;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000037;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000038;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000039;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000040;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000041;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000042;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000043;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000044;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000045;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000046;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000047;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000048;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000049;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000050;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000051;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000052;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000053;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000054;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000055;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000056;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000057;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000058;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000059;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000060;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000061;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000062;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000063;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000064;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000065;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000066;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2026-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000067;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050';
+END;
+GO
+
+COMMIT;
+GO
+

--- a/src/EPR.Payment.Service.Common.Data/Scripts/migrations.sql
+++ b/src/EPR.Payment.Service.Common.Data/Scripts/migrations.sql
@@ -6250,3 +6250,767 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000000;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000001;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000002;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000003;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000004;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000005;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000006;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000007;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000008;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000009;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000010;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000011;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000012;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000013;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000014;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000015;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000016;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000017;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000018;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000019;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000020;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000021;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000022;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000023;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000024;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000025;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000026;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000027;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000028;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000029;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000030;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000031;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000032;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000033;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000034;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000035;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000036;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000037;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000038;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000039;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000040;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000041;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000042;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000043;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000044;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000045;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000046;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000047;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000048;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000049;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000050;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000051;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000052;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000053;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000054;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000055;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000056;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000057;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000058;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000059;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000060;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000061;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000062;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000063;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000064;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000065;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000066;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    EXEC(N'UPDATE [Lookup].[RegistrationFees] SET [EffectiveTo] = ''2050-12-31T23:59:59.0000000Z''
+    WHERE [Id] = 26000067;
+    SELECT @@ROWCOUNT');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260716085126_ExtendCurrentFeesEndDatesTo2050'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20260716085126_ExtendCurrentFeesEndDatesTo2050', N'8.0.28');
+END;
+GO
+
+COMMIT;
+GO
+

--- a/src/EPR.Payment.Service.Common.Data/SeedData/RegistrationFeesDataSeed.cs
+++ b/src/EPR.Payment.Service.Common.Data/SeedData/RegistrationFeesDataSeed.cs
@@ -51,13 +51,15 @@ namespace EPR.Payment.Service.Common.Data.SeedData
             var seedIndex = 0;
             var newRegistrationFees = new List<RegistrationFees>();
 
-            // 2026 fees
+            // 2026 fees. End date tactically extended to 31/12/2050 so fees keep
+            // being found for registrations/resubmissions on or after 01/01/2027,
+            // until the 2027 statutory fee schedule is available.
             seedIndex = 26000000;
             AddProducerFeesForPeriod(
                 newRegistrationFees,
                 Fees2026,
                 new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-                new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc),
+                new DateTime(2050, 12, 31, 23, 59, 59, DateTimeKind.Utc),
                 ref seedIndex);
 
             builder.HasData(newRegistrationFees);


### PR DESCRIPTION
…to December 31, 2050. This includes updates to the RegistrationFees table and corresponding SQL scripts for both migration and rollback. Adjusted seed data to reflect the new end date for 2026 fees, ensuring continued availability for registrations and resubmissions until the 2027 fee schedule is established.